### PR TITLE
Detect error messages in response output

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,25 @@
 
 Utilities for testing Drupal!
 
+## ErrorMessageDetectionTrait
+
+A trait to detect error messages in `drupalGet` responses and display the error message when the test fails.
+
+### Usage
+
+Once your trait is added to your test base class, you can check detect errors by overriding the `drupalGet` function.
+
+```php
+/**
+ * {@inheritdoc}
+ */
+protected function drupalGet($path, array $options = [], array $headers = []): string {
+  $response = parent::drupalGet($path, $options, $headers);
+  $this->detectErrorMessageInResponseOutput($response);
+  return $response;
+}
+```
+
 ## ExpectsCacheableResponseTrait
 
 A trait to add Dynamic Page Cache cacheability testing to every request in your Functional tests.

--- a/src/Traits/ErrorMessageDetectionTrait.php
+++ b/src/Traits/ErrorMessageDetectionTrait.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PNX\DrupalTestUtils\Traits;
+
+use Drupal\Component\Utility\Html;
+
+/**
+ * Helper functions to detect if the response output contains an error.
+ */
+trait ErrorMessageDetectionTrait {
+
+  /**
+   * Detects an error in the response output and fails with the error message.
+   */
+  protected function detectErrorMessageInResponseOutput(string $response): void {
+    $error = 'The website encountered an unexpected error. Please try again later.';
+    if (str_starts_with($response, $error)) {
+      $plain = Html::decodeEntities(strip_tags(str_ireplace('<br>', "\n", $response)));
+      throw new \ErrorException($plain);
+    }
+  }
+
+}


### PR DESCRIPTION
Before:

```
Testing /data/app/modules/custom/snsw_news/tests/src/Functional

Behat\Mink\Exception\ElementNotFoundException : Element matching css "article .tile-grid a:first-child" not found.
```

After:

```
Testing /data/app/modules/custom/snsw_news/tests/src/Functional

ErrorException : The website encountered an unexpected error. Please try again later.

Error: Call to undefined method Drupal\Core\Field\FieldItemList::viewzzz() in Drupal\snsw_profile\Entity\Node\News->build() (line 187 of profiles/custom/snsw_profile/src/Entity/Node/News.php). Drupal\snsw_profile\Handler\SnswNodeViewBuilder->getBuildDefaults() (Line: 157)
```