### PR TITLE
HOTFIX: lastCreateEntity should not be nullable

### DIFF
--- a/src/Traits/EntityLoadTrait.php
+++ b/src/Traits/EntityLoadTrait.php
@@ -27,7 +27,7 @@ trait EntityLoadTrait {
   /**
    * Load the last created entity of a given type.
    */
-  protected function lastCreatedEntity(string $type): ?EntityInterface {
+  protected function lastCreatedEntity(string $type): EntityInterface {
     $type_manager = \Drupal::entityTypeManager();
     $id_key = $type_manager->getDefinition($type)->getKey('id');
     $results = \Drupal::entityQuery($type)->sort($id_key, 'DESC')->range(0, 1)->accessCheck(FALSE)->execute();


### PR DESCRIPTION
Technically `\Drupal\Core\Entity\EntityStorageInterface::load` is nullable, but if we return null here we need to add lots of checks to see if `lastCreatedEntity` returned null. It's probably better to throw an exception in here, but reverting to not nullable seems to do ok.